### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const toWGS = (coordinates) => {
 
     const zone = +(coordinates.x+'')[0]
 
-    const projected = proj4(epsg[epsgFromZone(zone)], 'WGS84', Object.assign({}, coordinates))
+    const projected = proj4.default(epsg[epsgFromZone(zone)], 'WGS84', Object.assign({}, coordinates))
     return ({
         longitude: projected.x,
         latitude: projected.y


### PR DESCRIPTION
index.js, line 23 was this one:
const projected = proj4(epsg[epsgFromZone(zone)], 'WGS84', Object.assign({}, coordinates))
and it fails with message: proj4 is not a function
I have tried this (and it works):
const projected = proj4.default(epsg[epsgFromZone(zone)], 'WGS84', Object.assign({}, coordinates))